### PR TITLE
write_riemann: avoid deadlocks, rate limit log messages.

### DIFF
--- a/src/daemon/utils_complain.c
+++ b/src/daemon/utils_complain.c
@@ -102,4 +102,3 @@ void c_do_release (int level, c_complain_t *c, const char *format, ...)
 } /* c_release */
 
 /* vim: set sw=4 ts=4 tw=78 noexpandtab : */
-

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -46,6 +46,7 @@
 #define RIEMANN_BATCH_MAX      8192
 
 struct riemann_host {
+    c_complain_t init_complaint;
 	char			*name;
 	char			*event_service_prefix;
 	pthread_mutex_t	 lock;
@@ -56,7 +57,6 @@ struct riemann_host {
 	_Bool			 always_append_ds;
 	char			*node;
 	int			 port;
-    c_complain_t init_complaint;
 	riemann_client_type_t	 client_type;
 	riemann_client_t	*client;
 	double			 ttl_factor;

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -135,8 +135,10 @@ static int wrr_send(struct riemann_host *host, riemann_message_t *msg) /* {{{ */
 	pthread_mutex_lock (&host->lock);
 
 	status = wrr_connect(host);
-	if (status != 0)
+	if (status != 0) {
+        pthread_mutex_unlock(&host->lock);
 		return status;
+    }
 
 	status = riemann_client_send_message(host->client, msg);
 	if (status != 0) {

--- a/src/write_riemann.c
+++ b/src/write_riemann.c
@@ -57,7 +57,6 @@ struct riemann_host {
 	char			*node;
 	int			 port;
     c_complain_t init_complaint;
-    c_complain_t init_send_complaint;
 	riemann_client_type_t	 client_type;
 	riemann_client_t	*client;
 	double			 ttl_factor;


### PR DESCRIPTION
Before you do the indenting sanitization commit, this would be nice, it does two things:

- [X] Avoid deadlocking on connection failures
- [X] Avoid spamming logs with repeated messages, using utils_complain.

This is meant to complement collectd/collectd#986